### PR TITLE
Support Local Filepaths 🚀

### DIFF
--- a/catapult.cpp
+++ b/catapult.cpp
@@ -113,7 +113,7 @@ static void open(std::string location)
 		ShellExecuteA(NULL, "open", location.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	#else
 		// On Linux, use the system() function to open the location
-		std::string command = "xdg-open " + url;
+		std::string command = "xdg-open " + location;
 		system(command.c_str());
 	#endif
 }

--- a/catapult.cpp
+++ b/catapult.cpp
@@ -43,14 +43,10 @@ int main(int argc, char *argv[])
 		return 1;	// Exit with error code
 	}
 
-	// Extract the URLs from the file
-	std::vector<std::string> urls = extractUrls(file);
-
-	// Open each URL in the default browser
-	for (std::string url : urls)
+	// Extract the locations from the file and open them
+	for (std::string location : extractLocations(file))
 	{
-		// ? May need to add a delay here to avoid opening too many browser tabs at once
-		openUrlInBrowser(url);
+		open(location);
 	}
 
 	// Close the file
@@ -67,19 +63,19 @@ int main(int argc, char *argv[])
 static void displayHelp()
 {
 	std::cout << "Usage: catapult.exe [filename]" << std::endl;
-	std::cout << "Opens all URLs in the specified file in the default browser" << std::endl;
+	std::cout << "Opens all URLs and Applications in the specified file" << std::endl;
 	std::cout << std::endl;
 	std::cout << "Arguments:" << std::endl;
-	std::cout << "  filename    The name of the file containing the URLs to open" << std::endl;
+	std::cout << "  filename    The name of the file containing the paths/URLs to open" << std::endl;
 	std::cout << std::endl;
 	std::cout << "Options:" << std::endl;
 	std::cout << "  -h, --help  Display this help message" << std::endl;
 }
 
-static std::vector<std::string> extractUrls(std::ifstream& file)
+static std::vector<std::string> extractLocations(std::ifstream& file)
 {
-	// A vector to store the URLs
-	std::vector<std::string> urls;
+	// A vector to store the locations
+	std::vector<std::string> locations;
 
 	// Read and process each line of the file
 	std::string line;
@@ -90,33 +86,21 @@ static std::vector<std::string> extractUrls(std::ifstream& file)
 		{
 			continue;
 		}
-
-		// Create a regular expression to match URLs
-		std::regex urlRegex("(https://[^\\s/$.?#].[^\\s]*)");
-
-		// Search for matches in the current line
-		std::smatch matches;
-		if (std::regex_search(line, matches, urlRegex))
-		{
-			// Extract the URL from the match
-			std::string url = matches.str(1);
-
-			// Add the URL to the vector
-			urls.push_back(url);
-		}
+		// Add the location to the vector
+		locations.push_back(line);
 	}
 
-	// Return the vector of URLs
-	return urls;
+	// Return the vector of locations
+	return locations;
 }
 
-static void openUrlInBrowser(std::string url)
+static void open(std::string location)
 {
 	#ifdef _WIN32
 		// On Windows, use the ShellExecute function
-		ShellExecuteA(NULL, "open", url.c_str(), NULL, NULL, SW_SHOWNORMAL);
+		ShellExecuteA(NULL, "open", location.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	#else
-		// On Linux, use the system() function to open a URL in the default browser
+		// On Linux, use the system() function to open the location
 		std::string command = "xdg-open " + url;
 		system(command.c_str());
 	#endif

--- a/catapult.cpp
+++ b/catapult.cpp
@@ -15,7 +15,7 @@
 #endif
 
 // A regular expression to match URLs
-std::regex urlRegex("^https://[^\s/$.?#].[^\s]*$");
+std::regex urlRegex("^https://[^\\s/$.?#].[^\\s]*$");
 
 // ====
 // MAIN

--- a/catapult.cpp
+++ b/catapult.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <regex>
 #include <vector>
+#include <filesystem>
 #include "catapult.h"
 
 // Platform-specific libraries
@@ -12,6 +13,9 @@
 #else
 	#include <cstdlib>
 #endif
+
+// A regular expression to match URLs
+std::regex urlRegex("^https://[^\s/$.?#].[^\s]*$");
 
 // ====
 // MAIN
@@ -86,8 +90,16 @@ static std::vector<std::string> extractLocations(std::ifstream& file)
 		{
 			continue;
 		}
-		// Add the location to the vector
-		locations.push_back(line);
+		// Add the URL to the vector
+		else if (std::regex_match(line, urlRegex))
+		{
+			locations.push_back(line);
+		}
+		// Add valid file paths to the vector
+		else if (std::filesystem::exists(line))
+		{
+			locations.push_back(line);
+		}
 	}
 
 	// Return the vector of locations

--- a/catapult.h
+++ b/catapult.h
@@ -8,20 +8,21 @@ int main(int argc, char* argv[]);
 static void displayHelp();
 
 /// <summary>
-/// This function extracts URLs from a file and returns them in a vector.
+/// This function extracts the locations from a file and returns them in a vector. A 
+/// location can be a URL or a file path.
 /// </summary>
 /// <param name="file">
-/// The file to extract URLs from. The file must be open before calling this function.
+/// The file to extract locations from. The file must be open before calling this function.
 /// </param>
 /// <returns>
-/// A vector of strings, each string being a URL found in the file.
+/// A vector of strings, each string being a location found in the file.
 /// </returns>
-static std::vector<std::string> extractUrls(std::ifstream& file);
+static std::vector<std::string> extractLocations(std::ifstream& file);
 
 /// <summary>
-/// This function opens a URL in the default browser.
+/// This function opens a location. A location can be a URL or a file path.
 /// </summary>
-/// <param name="url">
-/// The URL to open.
+/// <param name="location">
+/// The location to open.
 /// </param>
-static void openUrlInBrowser(std::string url);
+static void open(std::string location);

--- a/catapult.vcxproj
+++ b/catapult.vcxproj
@@ -118,6 +118,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/catapult.vcxproj.filters
+++ b/catapult.vcxproj.filters
@@ -30,5 +30,18 @@
     <ClInclude Include="catapult.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="catapult.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="icon\catapult.ico">
+      <Filter>Resource Files</Filter>
+    </Image>
   </ItemGroup>
 </Project>

--- a/test.catapult
+++ b/test.catapult
@@ -1,6 +1,7 @@
 https://www.google.com
 https://www.github.com
-Not a URL
+# Not a URL (TODO: Handle Invalid Locations)
+C:\Users\shres\.gitconfig
 
 # This is a comment
 # https://www.bing.com

--- a/test.catapult
+++ b/test.catapult
@@ -3,7 +3,7 @@ https://www.github.com
 
 Not a URL or a file path
 
-C:\Users\shres\.gitconfig
+~/.gitconfig
 
 # This is a comment
 # https://www.bing.com

--- a/test.catapult
+++ b/test.catapult
@@ -1,6 +1,8 @@
 https://www.google.com
 https://www.github.com
-# Not a URL (TODO: Handle Invalid Locations)
+
+Not a URL or a file path
+
 C:\Users\shres\.gitconfig
 
 # This is a comment


### PR DESCRIPTION
Allow catapult to "start"/"open" local file paths in addition to URLs. This will enable the user to launch multiple local applications (along with websites) using a single click.